### PR TITLE
hook update

### DIFF
--- a/.github/workflows/mattermost-doc-alerts.yml
+++ b/.github/workflows/mattermost-doc-alerts.yml
@@ -8,7 +8,6 @@ on:
   pull_request_review_comment:
   pull_request:
     types: [opened, reopened, ready_for_review, closed]
-  push:
   fork:
   release:
     types: [released]


### PR DESCRIPTION
  GitHub (4 repos):                                                                                
  - docusaurus-shared: removed push: only (no path filter — all PRs are doc-related)
                                                                                                                                                                        