### PR TITLE
Fix nightly Mattermost notification missing avatar_url

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,7 +125,7 @@ jobs:
             --arg run_url "https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
             '{
               repository: { full_name: $repo, html_url: $repo_url },
-              sender: { login: "ziti-ci" },
+              sender: { login: "ziti-ci", avatar_url: "https://raw.githubusercontent.com/netfoundry/branding/refs/heads/main/images/png/icon/netfoundry-icon-color.png" },
               schedule: "0 2 * * *",
               run_url: $run_url
             }')


### PR DESCRIPTION
## Summary

- The `ziti-mattermost-action-py` action requires an `avatar_url` field on the sender object
- The synthetic sender built in the "Build schedule event context" step for scheduled runs only included `login`, causing a `KeyError: 'avatar_url'` crash in `zhook.py`
- Added `avatar_url` pointing to the NetFoundry branding icon (same icon used as the site favicon)
