### PR TITLE
fix: use docsBase prefix for platform and frontdoor Scalar spec URLs

### DIFF
--- a/unified-doc/docusaurus.config.ts
+++ b/unified-doc/docusaurus.config.ts
@@ -406,14 +406,14 @@ const config: Config = {
             label: 'API reference',
             route: `/${routeBase('platform')}/api-guides/openapi-reference`,
             showNavLink: false,
-            configuration: {url: '/console-api-spec.yaml', hideClientButton: true, hideTestRequestButton: true},
+            configuration: {url: `${docsBase}console-api-spec.yaml`, hideClientButton: true, hideTestRequestButton: true},
         } as ScalarOptions],
         build(BUILD_FLAGS.FRONTDOOR) && ['@scalar/docusaurus', {
             id: 'frontdoor-api',
             label: 'API reference',
             route: `/${routeBase('frontdoor')}/reference/api-reference`,
             showNavLink: false,
-            configuration: {url: '/frontdoor-api-spec.yaml', hideClientButton: true, hideTestRequestButton: true},
+            configuration: {url: `${docsBase}frontdoor-api-spec.yaml`, hideClientButton: true, hideTestRequestButton: true},
         } as ScalarOptions],
     ].filter(Boolean),
     themeConfig: {


### PR DESCRIPTION
## Summary

- Platform and frontdoor Scalar API pages were showing "Document 'api-1' could not be loaded"
- Root cause: Scalar fetches spec files via HTTP URL; with `baseUrl='/docs/'`, static files are
  at `/docs/console-api-spec.yaml` not `/console-api-spec.yaml`
- Fix: prefix both spec URLs with `docsBase` (non-Vercel: `/docs/`, Vercel: `/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)