### PR TITLE
update dependencies to 3.10

### DIFF
--- a/unified-doc/build-docs.ps1
+++ b/unified-doc/build-docs.ps1
@@ -25,7 +25,7 @@
 [CmdletBinding()]
 param(
     # Branch to clone for each remote repo
-    [string]$ZitiDocBranch    = "docusaurus-3.10",
+    [string]$ZitiDocBranch    = "main",
     [string]$ZrokBranch       = "main",
     [string]$FrontdoorBranch  = "develop",
     [string]$SelfhostedBranch = "main",

--- a/unified-doc/build-docs.ps1
+++ b/unified-doc/build-docs.ps1
@@ -25,7 +25,7 @@
 [CmdletBinding()]
 param(
     # Branch to clone for each remote repo
-    [string]$ZitiDocBranch    = "main",
+    [string]$ZitiDocBranch    = "docusaurus-3.10",
     [string]$ZrokBranch       = "main",
     [string]$FrontdoorBranch  = "develop",
     [string]$SelfhostedBranch = "main",

--- a/unified-doc/docusaurus.config.ts
+++ b/unified-doc/docusaurus.config.ts
@@ -134,6 +134,31 @@ console.log("    hotjar app         : " + cfg.hotjar.id);
 console.log('REMARK_MAPPINGS:', JSON.stringify(REMARK_MAPPINGS, null, 2));
 
 
+// Promotes the %%HEADING_ID:slug%% marker (emitted by the site-level preprocessor
+// for .mdx files that originally used `## Heading {#slug}` syntax) into the
+// heading's real `id` attribute. This is the AST-stage counterpart to the
+// preprocessor: together they replace Docusaurus's built-in {#id} handling for
+// .mdx files (which doesn't survive MDX micromark tokenization under
+// future.v4 / 3.10+), while producing real heading IDs that Docusaurus's anchor
+// validator can see.
+function remarkPromoteHeadingId() {
+    const {visit} = require('unist-util-visit');
+    return (tree: any) => {
+        visit(tree, 'heading', (node: any) => {
+            const last = node.children[node.children.length - 1];
+            if (!last || last.type !== 'text') return;
+            const m = last.value.match(/^(.*?)\s*xHIDx([a-zA-Z][\w-]*)xHIDx\s*$/s);
+            if (!m) return;
+            last.value = m[1].replace(/\s+$/, '');
+            if (last.value === '') node.children.pop();
+            node.data = node.data || {};
+            node.data.id = m[2];
+            node.data.hProperties = node.data.hProperties || {};
+            node.data.hProperties.id = m[2];
+        });
+    };
+}
+
 function extendDocsPlugins(plugin: PluginConfig): PluginConfig {
     if (!Array.isArray(plugin)) return plugin;
 
@@ -141,6 +166,7 @@ function extendDocsPlugins(plugin: PluginConfig): PluginConfig {
 
     config.beforeDefaultRemarkPlugins = [
         ...(config.beforeDefaultRemarkPlugins || []),
+        remarkPromoteHeadingId,
         remarkGithubAdmonitionsToDirectives,
     ];
 
@@ -149,12 +175,6 @@ function extendDocsPlugins(plugin: PluginConfig): PluginConfig {
         [remarkScopedPath, { mappings: REMARK_MAPPINGS, logLevel: LogLevel.Silent }],
         [remarkCodeSections, { logLevel: LogLevel.Silent }],
     ];
-
-    // Force per-file detection: .md uses CommonMark, .mdx uses strict MDX.
-    // Overrides whatever the imported plugin config from _remotes/ set, so
-    // upstream content with {#heading-ids} or raw <!-- comments --> parses
-    // correctly under future.v4 / Docusaurus 3.10+.
-    config.format = 'detect';
 
     return [pluginName, config];
 }
@@ -238,6 +258,29 @@ const config: Config = {
         // Important under future.v4 -- without this, .md files get MDX-parsed and
         // upstream content from _remotes/ breaks.
         format: 'detect',
+        // Source-level rewrites for .mdx files from upstream remotes that use
+        // CommonMark-only syntax (HTML comments, `{#id}` heading anchors). Runs
+        // before MDX micromark tokenization, so we can transform without forking
+        // upstream content. Only .mdx files are touched; .md files already parse
+        // as CommonMark under format:'detect'.
+        preprocessor: ({filePath, fileContent}) => {
+            if (!filePath.endsWith('.mdx')) return fileContent;
+            let out = fileContent;
+            // <!-- ... --> -> {/* ... */}  (works for single- and multi-line)
+            out = out.replace(/<!--([\s\S]*?)-->/g, (_m, body) => `{/*${body}*/}`);
+            // `## Heading {#id}` -> `## Heading xHIDxidxHIDx`. MDX strict mode
+            // treats `{` as a JSX expression start so the original syntax fails;
+            // the marker is plain alphanumeric text (no `:` or `%`, which MDX
+            // splits text nodes on) that survives micromark tokenization, and is
+            // then promoted to a real heading `id` by remarkPromoteHeadingId.
+            // The result is an actual <h2 id="..."> that Docusaurus's anchor
+            // validator sees.
+            out = out.replace(
+                /^(#{1,6}[ \t]+.+?)[ \t]*\{#([a-zA-Z][\w-]*)\}[ \t]*$/gm,
+                '$1 xHIDx$2xHIDx'
+            );
+            return out;
+        },
     },
     staticDirectories: [
         'static',

--- a/unified-doc/yarn.lock
+++ b/unified-doc/yarn.lock
@@ -1841,7 +1841,7 @@
     webpack "^5.95.0"
     webpackbar "^7.0.0"
 
-"@docusaurus/core@3.10.1", "@docusaurus/core@^3.10.0":
+"@docusaurus/core@3.10.1", "@docusaurus/core@^3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-3.10.1.tgz#3f8bdb97451b4df14f2a3b39ab0186366fbf8fbe"
   integrity sha512-3pf2fXXw0eVk8WnC3T4LIigRDupcpvngpKo9Vy7mYyBhuddc0klDUuZAIfzMoK6z05pdlk6EFC/vBSX43+1O5w==
@@ -1899,7 +1899,7 @@
     postcss-sort-media-queries "^5.2.0"
     tslib "^2.6.0"
 
-"@docusaurus/faster@^3.10.0":
+"@docusaurus/faster@^3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/faster/-/faster-3.10.1.tgz#a63d89ae980c98e1eeab3ff15ee083f7c20ed353"
   integrity sha512-XTZhE5C1gZ/DaYYMlSk02dwP5vhpQON5QHVz1s3892mSESAywgWanURpXEDAvt4GvGuq7s+XP8rTWHZvfaJmdQ==
@@ -1953,7 +1953,7 @@
     vfile "^6.0.1"
     webpack "^5.88.1"
 
-"@docusaurus/module-type-aliases@3.10.1", "@docusaurus/module-type-aliases@^3.10.0":
+"@docusaurus/module-type-aliases@3.10.1", "@docusaurus/module-type-aliases@^3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz#22d39177c296786eb6e0d940699cd590cc93ca77"
   integrity sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==
@@ -1966,7 +1966,7 @@
     react-helmet-async "npm:@slorber/react-helmet-async@1.3.0"
     react-loadable "npm:@docusaurus/react-loadable@6.0.0"
 
-"@docusaurus/plugin-client-redirects@^3.10.0":
+"@docusaurus/plugin-client-redirects@^3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.1.tgz#e22ed20e5837b7c3a28258e3d1816c4239c82b36"
   integrity sha512-LHgd+YDvkhfOHMAE6XtUng3DQNzVM765RqVRrMJgHtzAvfopQhY6ieprqjxDVBdv21cLma6I0jHr+YCZH8fL9A==
@@ -2127,7 +2127,7 @@
     tslib "^2.6.0"
     webpack "^5.88.1"
 
-"@docusaurus/preset-classic@^3.10.0":
+"@docusaurus/preset-classic@^3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-3.10.1.tgz#faf330d96aedc9083a59bec09d966ae4dfc8b2fb"
   integrity sha512-YO/FL8v1zmbxoTso6mjMz/RDjhaTJxb1UpFFTDdY5847LLDCeyYiYlrhyTbgN1RIN3xnkLKZ9Lj1x8hUzI4JOg==
@@ -2198,7 +2198,7 @@
     tslib "^2.6.0"
     utility-types "^3.10.0"
 
-"@docusaurus/theme-mermaid@^3.10.0":
+"@docusaurus/theme-mermaid@^3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/theme-mermaid/-/theme-mermaid-3.10.1.tgz#dada9c50c780524d246906234ace8a35446f26fc"
   integrity sha512-2gxpmln8Pc4EN1oWzshQEx2HTs67jk14v7MmgqGs8ZU7Nm8oihg+fTouof2u4vN8DtB3Fln4cDJu4UprSX1S3Q==
@@ -2211,7 +2211,7 @@
     mermaid ">=11.6.0"
     tslib "^2.6.0"
 
-"@docusaurus/theme-search-algolia@3.10.1", "@docusaurus/theme-search-algolia@^3.10.0":
+"@docusaurus/theme-search-algolia@3.10.1", "@docusaurus/theme-search-algolia@^3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.1.tgz#6f422058711629ce8d7c2f17e1e54efa075c626e"
   integrity sha512-OTaARARVZj2GvkJQjB+1jOIxntRaXea+G+fMsNqrZBAU1O1vJKDW22R7kECOHW27oJCLFN9HKaZeRrfAUyviug==
@@ -2242,12 +2242,12 @@
     fs-extra "^11.1.1"
     tslib "^2.6.0"
 
-"@docusaurus/tsconfig@^3.10.0":
+"@docusaurus/tsconfig@^3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/tsconfig/-/tsconfig-3.10.1.tgz#1db31b4a4a5c914bdffa80070a35b6365d34f2e8"
   integrity sha512-rYvB7yqkdqWIpAbDzQljGfM4cDBkLTbhmagZBEcsyj6oPUsz47lmW2pYdN1j+7sGFgltbAmQH62xfbrij4Eh6Q==
 
-"@docusaurus/types@3.10.1", "@docusaurus/types@^3.10.0":
+"@docusaurus/types@3.10.1", "@docusaurus/types@^3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-3.10.1.tgz#d42837938ae43ca2be0ca47e63e00476b5eb94be"
   integrity sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==
@@ -2840,6 +2840,23 @@
     micromark-factory-space "^1.0.0"
     micromark-util-character "^1.1.0"
     micromark-util-symbol "^1.0.1"
+
+"@solid-primitives/refs@^1.0.5":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@solid-primitives/refs/-/refs-1.1.3.tgz#9330120f0788daef9964ceccddd7a7c304c286b5"
+  integrity sha512-aam02fjNKpBteewF/UliPSQCVJsIIGOLEWQOh+ll6R/QePzBOOBMcC4G+5jTaO75JuUS1d/14Q1YXT3X0Ow6iA==
+  dependencies:
+    "@solid-primitives/utils" "^6.4.0"
+
+"@solid-primitives/transition-group@^1.0.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@solid-primitives/transition-group/-/transition-group-1.1.2.tgz#be9af05871a7ca6323277f9782f4aeb20cb7f73f"
+  integrity sha512-gnHS0OmcdjeoHN9n7Khu8KNrOlRc8a2weETDt2YT6o1zeW/XtUC6Db3Q9pkMU/9cCKdEmN4b0a/41MKAHRhzWA==
+
+"@solid-primitives/utils@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@solid-primitives/utils/-/utils-6.4.0.tgz#45257521d258cffd563b40d62163058af75496ae"
+  integrity sha512-AeGTBg8Wtkh/0s+evyLtP8piQoS4wyqqQaAFs2HJcFMMjYAtUgo+ZPduRXLjPlqKVc2ejeR544oeqpbn8Egn8A==
 
 "@svgr/babel-plugin-add-jsx-attribute@8.0.0":
   version "8.0.0"
@@ -4147,13 +4164,14 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
-asciinema-player@^3.10.0:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/asciinema-player/-/asciinema-player-3.10.0.tgz#6b4b74b6ce85906b9930f0cf0dc71cf89e50e202"
-  integrity sha512-shoOK6F606nDKZxDVM7JuGSCAyWLePoGRFNlV+FqiP5Sqvyn0BlE7wlbjZyd2X4P1iRhv/HKfVNtnQIxmgphRA==
+asciinema-player@^3.10.1:
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/asciinema-player/-/asciinema-player-3.15.1.tgz#3facad2782330f4c843f9fdbbf339be405d0bfea"
+  integrity sha512-agVYeNlPxthLyAb92l9AS7ypW0uhesqOuQzyR58Q4Sj+MvesQztZBgx86lHqNJkB8rQ6EP0LeA9czGytQUBpYw==
   dependencies:
     "@babel/runtime" "^7.21.0"
     solid-js "^1.3.0"
+    solid-transition-group "^0.2.3"
 
 ast-types@^0.13.4:
   version "0.13.4"
@@ -11055,6 +11073,14 @@ solid-js@^1.3.0:
     csstype "^3.1.0"
     seroval "~1.3.0"
     seroval-plugins "~1.3.0"
+
+solid-transition-group@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/solid-transition-group/-/solid-transition-group-0.2.3.tgz#ef441d9e4620cddc4d29cdbc958b09f94db515c4"
+  integrity sha512-iB72c9N5Kz9ykRqIXl0lQohOau4t0dhel9kjwFvx81UZJbVwaChMuBuyhiZmK24b8aKEK0w3uFM96ZxzcyZGdg==
+  dependencies:
+    "@solid-primitives/refs" "^1.0.5"
+    "@solid-primitives/transition-group" "^1.0.2"
 
 sort-css-media-queries@2.2.0:
   version "2.2.0"


### PR DESCRIPTION
this should hopefully get resolved with the 4.0 release. 

Docusaurus 3.10.1 + future.v4 = broken build. Two fixes:

  1. Drop invalid `config.format='detect'` from per-plugin docs config -- 3.10's schema rejects it. Site-level
     `markdown.format='detect'` already covers it.

  2. Polyfill the `{#id}` heading anchors and `<!-- -->` comments in upstream `.mdx` from `_remotes/`. Under v4-strict
     MDX, both blow up micromark before Docusaurus's built-in heading-id plugin gets a turn. Can't fix the files
     (`_remotes/` is upstream, gets clobbered on every `build-docs.sh`). MDX wontfix'd it, Docusaurus can't-repro'd it.
     Site-level `markdown.preprocessor` rewrites the source pre-tokenization; companion remark plugin promotes the
     placeholder into a real `<h2 id="...">` so Docusaurus's anchor validator sees it. Same shape Docusaurus's own MDX2
     migration used.

  Refs:
  - https://github.com/mdx-js/mdx/issues/2485 -- wontfix from MDX
  - https://github.com/facebook/docusaurus/issues/11235 -- can't-repro from Docusaurus
  - https://github.com/facebook/docusaurus/pull/8788 -- precedent for the polyfill pattern