### PR TITLE
fix nightly build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -157,11 +157,7 @@ jobs:
           COUNT=$(jq '.count' "$REPORT")
           PATHS=$(jq -r '.unresolved[]' "$REPORT" | head -20 | sed 's/^/- /')
           RUN_URL="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-          BODY="❌ **${COUNT} path(s) removed with no redirect** — build blocked before publish.
-
-${PATHS}
-
-[View build logs](${RUN_URL})"
+          BODY=$(printf '❌ **%s path(s) removed with no redirect** — build blocked before publish.\n\n%s\n\n[View build logs](%s)' "${COUNT}" "${PATHS}" "${RUN_URL}")
           EVENT_JSON=$(jq -cn \
             --arg repo "$GITHUB_REPOSITORY" \
             --arg repo_url "https://github.com/$GITHUB_REPOSITORY" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,29 +147,7 @@ jobs:
       - name: Build drift alert context
         id: drift-ctx
         if: failure()
-        run: |
-          REPORT="unified-doc/build-site/sitemap-drift.json"
-          if [ ! -f "$REPORT" ]; then
-            echo "has_drift=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "has_drift=true" >> "$GITHUB_OUTPUT"
-          COUNT=$(jq '.count' "$REPORT")
-          PATHS=$(jq -r '.unresolved[]' "$REPORT" | head -20 | sed 's/^/- /')
-          RUN_URL="https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
-          BODY=$(printf '❌ **%s path(s) removed with no redirect** — build blocked before publish.\n\n%s\n\n[View build logs](%s)' "${COUNT}" "${PATHS}" "${RUN_URL}")
-          EVENT_JSON=$(jq -cn \
-            --arg repo "$GITHUB_REPOSITORY" \
-            --arg repo_url "https://github.com/$GITHUB_REPOSITORY" \
-            --arg run_url "$RUN_URL" \
-            --arg action "$BODY" \
-            '{
-              repository: { full_name: $repo, html_url: $repo_url, stargazers_count: 0 },
-              sender: { login: "ziti-ci", url: "https://api.github.com/users/netfoundry", html_url: "https://github.com/netfoundry", avatar_url: "https://raw.githubusercontent.com/netfoundry/branding/refs/heads/main/images/png/icon/netfoundry-icon-color.png" },
-              action: $action,
-              run_url: $run_url
-            }')
-          echo "event-json=$EVENT_JSON" >> "$GITHUB_OUTPUT"
+        run: unified-doc/scripts/build-drift-alert-context.sh "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID" "$GITHUB_OUTPUT"
 
       - name: Send drift alert
         if: failure() && steps.drift-ctx.outputs.has_drift == 'true'

--- a/unified-doc/scripts/build-drift-alert-context.sh
+++ b/unified-doc/scripts/build-drift-alert-context.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Build the drift-alert context for the Mattermost notification step.
+#
+# Usage: build-drift-alert-context.sh <repo> <run-id> <github-output> [report]
+#
+#   repo            GitHub repository slug (e.g. netfoundry/docusaurus-shared)
+#   run-id          GitHub Actions run ID (or any string when testing locally)
+#   github-output   Path to write key=value outputs (/dev/stdout works for local testing)
+#   report          Path to sitemap-drift.json
+#                   (default: unified-doc/build-site/sitemap-drift.json)
+
+set -euo pipefail
+
+REPO="${1:?Usage: $0 <repo> <run-id> <github-output> [report]}"
+RUN_ID="${2:?missing run-id}"
+OUTPUT_FILE="${3:?missing github-output path}"
+REPORT="${4:-unified-doc/build-site/sitemap-drift.json}"
+
+if [ ! -f "$REPORT" ]; then
+  echo "has_drift=false" >> "$OUTPUT_FILE"
+  exit 0
+fi
+
+echo "has_drift=true" >> "$OUTPUT_FILE"
+
+COUNT=$(jq '.count' "$REPORT")
+PATHS=$(jq -r '.unresolved[]' "$REPORT" | head -20 | sed 's/^/- /')
+RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
+
+BODY=$(printf '❌ **%s path(s) removed with no redirect** — build blocked before publish.\n\n%s\n\n[View build logs](%s)' \
+  "${COUNT}" "${PATHS}" "${RUN_URL}")
+
+EVENT_JSON=$(jq -cn \
+  --arg repo     "$REPO" \
+  --arg repo_url "https://github.com/$REPO" \
+  --arg run_url  "$RUN_URL" \
+  --arg action   "$BODY" \
+  '{
+    repository: { full_name: $repo, html_url: $repo_url, stargazers_count: 0 },
+    sender: {
+      login: "ziti-ci",
+      url: "https://api.github.com/users/netfoundry",
+      html_url: "https://github.com/netfoundry",
+      avatar_url: "https://raw.githubusercontent.com/netfoundry/branding/refs/heads/main/images/png/icon/netfoundry-icon-color.png"
+    },
+    action: $action,
+    run_url: $run_url
+  }')
+
+echo "event-json=$EVENT_JSON" >> "$OUTPUT_FILE"


### PR DESCRIPTION
`Root cause: The BODY= multi-line string assignment in the Build drift alert context step had ${PATHS} and [View build logs](...) at column 0 in the file. YAML block scalars require all content to be indented past the key's level — those unindented lines caused GitHub's YAML parser to error out, which also prevents the scheduler from seeing the workflow at all.`