### PR TITLE
support inline links in version banners; bump to 0.14.1

### DIFF
--- a/packages/docusaurus-theme/package.json
+++ b/packages/docusaurus-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netfoundry/docusaurus-theme",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "NetFoundry Docusaurus theme with shared layout, footer, and styling",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/packages/docusaurus-theme/src/options.ts
+++ b/packages/docusaurus-theme/src/options.ts
@@ -125,15 +125,27 @@ export interface NetFoundryThemeOptions {
 }
 
 /**
+ * An inline link to embed within a version banner message
+ */
+export interface VersionBannerLink {
+  /** Substring of message to render as an anchor. Must match the message exactly. */
+  text: string;
+  /** URL for the anchor. */
+  href: string;
+}
+
+/**
  * Version banner configuration for path-aware custom banners
  */
 export interface VersionBannerConfig {
   /** Path prefix to match — e.g. '/docs/openziti/maint' or '/docs/zrok/1.x' */
   pathPrefix: string;
-  /** Banner message (plain text). */
+  /** Banner message (plain text). Substrings listed in links are rendered as anchors. */
   message: string;
   /** Visual style. 'warning' (default) renders amber, 'info' renders blue, 'note' renders gray. */
   type?: 'warning' | 'info' | 'note';
+  /** Substrings within message to render as inline links. Each text must appear in message exactly. */
+  links?: VersionBannerLink[];
 }
 
 /**

--- a/packages/docusaurus-theme/theme/DocVersionBanner/index.tsx
+++ b/packages/docusaurus-theme/theme/DocVersionBanner/index.tsx
@@ -1,34 +1,43 @@
 import React, { type ReactNode } from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { useLocation } from 'react-router-dom';
-import type { ThemeConfigWithNetFoundry } from '../../src/options';
+import type { ThemeConfigWithNetFoundry, VersionBannerLink } from '../../src/options';
 
 type Props = { className?: string };
 
-/**
- * Path-aware version banner override.
- *
- * Renders the first matching entry from themeConfig.netfoundry.versionBanners
- * whose pathPrefix matches the current page URL. If no entry matches, renders
- * nothing — configure a versionBanners entry for every versioned path that
- * should display a banner.
- */
+function renderMessage(message: string, links?: VersionBannerLink[]): ReactNode {
+    if (!links?.length) return message;
+    let parts: (string | ReactNode)[] = [message];
+    for (const link of links) {
+        const next: (string | ReactNode)[] = [];
+        for (const part of parts) {
+            if (typeof part !== 'string') { next.push(part); continue; }
+            const idx = part.indexOf(link.text);
+            if (idx === -1) { next.push(part); continue; }
+            if (idx > 0) next.push(part.slice(0, idx));
+            next.push(<a key={link.text} href={link.href}>{link.text}</a>);
+            const after = part.slice(idx + link.text.length);
+            if (after) next.push(after);
+        }
+        parts = next;
+    }
+    return <>{parts}</>;
+}
+
 export default function DocVersionBanner({ className }: Props): ReactNode {
     const { siteConfig } = useDocusaurusContext();
     const { pathname } = useLocation();
     const themeConfig = siteConfig.themeConfig as ThemeConfigWithNetFoundry;
     const versionBanners = themeConfig.netfoundry?.versionBanners;
-
     const match = versionBanners?.find(b => pathname.startsWith(b.pathPrefix));
     if (!match) return null;
-
     const alertType = match.type === 'info' ? 'info' : match.type === 'note' ? 'secondary' : 'warning';
     return (
         <div
             className={['alert', `alert--${alertType}`, 'margin-bottom--md', className].filter(Boolean).join(' ')}
             role="alert"
         >
-            {match.message}
+            {renderMessage(match.message, match.links)}
         </div>
     );
 }


### PR DESCRIPTION
Add VersionBannerLink interface and links[] field to VersionBannerConfig. DocVersionBanner now splits the message string at each link.text substring and renders it as an <a> anchor, enabling inline links to docs versions or external pages (e.g. release policy) without requiring JSX in the config.