### PR TITLE
Wrap code on mobile to prevent horizontal page overflow, bump to 0.15.1

### DIFF
--- a/packages/docusaurus-theme/css/legacy.css
+++ b/packages/docusaurus-theme/css/legacy.css
@@ -1989,10 +1989,12 @@ code {
     white-space: pre;
 }
 
-/* Inline code must wrap; the rule above forces white-space: pre, which overflows the page on mobile. */
-:not(pre) > code {
-    white-space: normal;
-    overflow-wrap: anywhere;
+/* On mobile, let code wrap instead of overflowing the viewport. Overrides the
+   white-space: pre set above; pre-wrap keeps formatting but wraps long lines. */
+@media (max-width: 767px) {
+    code {
+        white-space: pre-wrap;
+    }
 }
 
 code p {

--- a/packages/docusaurus-theme/package.json
+++ b/packages/docusaurus-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netfoundry/docusaurus-theme",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "NetFoundry Docusaurus theme with shared layout, footer, and styling",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
On narrow screens the base `code` rule's white-space: pre lets long inline commands and code-block lines push the page past the viewport. Override it to pre-wrap inside @media (max-width: 996px) so code wraps on mobile while desktop rendering is unchanged.